### PR TITLE
Configurable speed thresholds 

### DIFF
--- a/custom_components/movement/calculations.py
+++ b/custom_components/movement/calculations.py
@@ -282,6 +282,8 @@ def update_or_maintain_mode(
     statistics: StatisticGroup,
     transition: TransitionRegistry,
     proposed_mode: ModeOfTransit | None,
+    biking_max: float = 16.0,
+    walking_max: float = 8.0,
 ) -> None:
     """Update the mode of transit if shouldn't be maintained at the prior value.
 
@@ -377,7 +379,11 @@ def update_or_maintain_mode(
             default_0(statistics.speed_recent_avg.value),
             default_0(statistics.speed_recent_max.value),
         )
-        constraint_mode = mode_of_transit_from_speed(speed_recent_combined_max)
+        constraint_mode = mode_of_transit_from_speed(
+            speed_recent_combined_max,
+            biking_max=biking_max,
+            walking_max=walking_max,
+        )
 
         _LOGGER.debug("constraint_mode: %s", constraint_mode)
 
@@ -464,7 +470,11 @@ def calculate_distance_adjustments(
     return distance_adjustments
 
 
-def mode_of_transit_from_speed(speed: float) -> ModeOfTransit:
+def mode_of_transit_from_speed(
+    speed: float,
+    biking_max: float = 16.0,
+    walking_max: float = 8.0,
+) -> ModeOfTransit:
     """Calculate mode of transit from speed.
 
     The following information is informative in making a judgment about speed
@@ -479,9 +489,9 @@ def mode_of_transit_from_speed(speed: float) -> ModeOfTransit:
     """
     return (
         ModeOfTransit.DRIVING
-        if speed >= 16
+        if speed >= biking_max
         else ModeOfTransit.BIKING
-        if speed >= 8
+        if speed >= walking_max
         else ModeOfTransit.WALKING
     )
 

--- a/custom_components/movement/config_flow.py
+++ b/custom_components/movement/config_flow.py
@@ -38,6 +38,8 @@ from .const import (
     CONF_TRACKED_ENTITY,
     CONF_TRIP_ADDITION,
     DOMAIN,
+    CONF_MAX_SPEED_BIKING,
+    CONF_MAX_SPEED_WALKING,
 )
 
 SECTION_ADVANCED_OPTIONS: Final = "advanced_options"
@@ -105,6 +107,37 @@ def _base_schema(user_input: dict[str, Any]) -> VolDictType:
             ),
             {"collapsed": True},
         ),
+        vol.Required("speed_thresholds"): section(
+            vol.Schema(
+                {
+                    vol.Required(
+                        CONF_MAX_SPEED_BIKING,
+                        default=user_input.get(CONF_MAX_SPEED_BIKING, 16.0),
+                    ): NumberSelector(
+                        NumberSelectorConfig(
+                            min=5,
+                            max=100,
+                            step=1,
+                            unit_of_measurement="km/h",
+                            mode=NumberSelectorMode.BOX,
+                        ),
+                    ),
+                    vol.Required(
+                        CONF_MAX_SPEED_WALKING,
+                        default=user_input.get(CONF_MAX_SPEED_WALKING, 8.0),
+                    ): NumberSelector(
+                        NumberSelectorConfig(
+                            min=1,
+                            max=20,
+                            step=1,
+                            unit_of_measurement="km/h",
+                            mode=NumberSelectorMode.BOX,
+                        ),
+                    ),
+                },
+            ),
+            {"collapsed": True},
+        ),
     }
 
 
@@ -139,6 +172,8 @@ class MovementConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
             The config flow result.
         """
         if user_input is not None:
+            speed_thresholds = user_input.pop("speed_thresholds", {})
+            user_input.update(speed_thresholds)
             self._async_abort_entries_match(user_input)
 
             title = cast(
@@ -211,9 +246,10 @@ class MovementOptionsFlow(OptionsFlow):
         """
         if user_input is not None:
             advanced_options = user_input.pop(SECTION_ADVANCED_OPTIONS)
+            speed_thresholds = user_input.pop("speed_thresholds", {})
             self.hass.config_entries.async_update_entry(
                 self.config_entry,
-                data={**self.config_entry.data, **user_input, **advanced_options},
+                data={**self.config_entry.data, **user_input, **advanced_options, **speed_thresholds},
             )
             return self.async_create_entry(title=self.config_entry.title, data={})
 

--- a/custom_components/movement/config_flow.py
+++ b/custom_components/movement/config_flow.py
@@ -117,7 +117,7 @@ def _base_schema(user_input: dict[str, Any]) -> VolDictType:
                         NumberSelectorConfig(
                             min=5,
                             max=100,
-                            step=1,
+                            step=0.1,
                             unit_of_measurement="km/h",
                             mode=NumberSelectorMode.BOX,
                         ),
@@ -129,7 +129,7 @@ def _base_schema(user_input: dict[str, Any]) -> VolDictType:
                         NumberSelectorConfig(
                             min=1,
                             max=20,
-                            step=1,
+                            step=0.1,
                             unit_of_measurement="km/h",
                             mode=NumberSelectorMode.BOX,
                         ),

--- a/custom_components/movement/const.py
+++ b/custom_components/movement/const.py
@@ -30,3 +30,5 @@ DEBOUNCE_UPDATES_DELTA: Final = dt.timedelta(seconds=5)
 
 MAX_RESTORE_HISTORY: Final = 25
 MAX_RESTORE_TRANSITION: Final = 25
+CONF_MAX_SPEED_BIKING: Final = "max_speed_biking"
+CONF_MAX_SPEED_WALKING: Final = "max_speed_walking"

--- a/custom_components/movement/coordinator.py
+++ b/custom_components/movement/coordinator.py
@@ -599,8 +599,10 @@ class MovementUpdateCoordinator(DataUpdateCoordinator[MovementData]):
                 transitioning = True
 
         # calculate mode of transit
+        biking_max = self.config_entry.data.get("max_speed_biking", 16.0)
+        walking_max = self.config_entry.data.get("max_speed_walking", 8.0)
         proposed_mode = (
-            mode_of_transit_from_speed(update.speed) if update.speed else None
+            mode_of_transit_from_speed(update.speed, biking_max=biking_max, walking_max=walking_max) if update.speed else None
         )
         try:
             update_or_maintain_mode(
@@ -609,6 +611,8 @@ class MovementUpdateCoordinator(DataUpdateCoordinator[MovementData]):
                 statistics=self.statistics,
                 transition=self.transition,
                 proposed_mode=proposed_mode,
+                biking_max=biking_max,
+                walking_max=walking_max,
             )
         except TransitionRequiredCondition as err:
             _LOGGER.log(

--- a/custom_components/movement/translations/en.json
+++ b/custom_components/movement/translations/en.json
@@ -27,6 +27,18 @@
                         },
                         "description": "Distance multiplers for different driving conditions",
                         "name": "Driving multipliers"
+                    },
+                    "speed_thresholds": {
+                        "data": {
+                            "max_speed_biking": "Max speed for biking",
+                            "max_speed_walking": "Max speed for walking"
+                        },
+                        "data_description": {
+                            "max_speed_biking": "Speeds above this will be classified as driving.",
+                            "max_speed_walking": "Speeds above this will be classified as biking."
+                        },
+                        "description": "Speed thresholds for calculating the mode of transit",
+                        "name": "Speed thresholds"
                     }
                 },
                 "title": "Movement"
@@ -121,6 +133,18 @@
                         },
                         "description": "Distance multiplers for different driving conditions",
                         "name": "Driving multipliers"
+                    },
+                    "speed_thresholds": {
+                        "data": {
+                            "max_speed_biking": "Max speed for biking",
+                            "max_speed_walking": "Max speed for walking"
+                        },
+                        "data_description": {
+                            "max_speed_biking": "Speeds above this will be classified as driving.",
+                            "max_speed_walking": "Speeds above this will be classified as biking."
+                        },
+                        "description": "Speed thresholds for calculating the mode of transit",
+                        "name": "Speed thresholds"
                     }
                 },
                 "title": "Movement"


### PR DESCRIPTION
I see you put in allot of work into this nice hacs integration for distance tracking. My usecase was for commuting with my e-mtb but it thinks I'm driving a car.
Here in the Netherlands the speeds of electric bikes is legally 25km\s. (speed pedelec even 45km\s) And other countries have other rules for their vehicles so it makes sense to make it configurable. 

When testing the interface might say speed_thresholds on the config page, then the json translate cache is still in browser memory. Quick ctrl-f5 refresh and your good to go.